### PR TITLE
Replace iTunes references with Music (fixes #40)

### DIFF
--- a/AppDelegate.h
+++ b/AppDelegate.h
@@ -29,8 +29,8 @@
 	NSTimer *timedQuitTimer;
 	int minutesRemainingToTimedQuit;
 	
-	// Spying on iTunes
-	BOOL iTunesIsPlaying;
+	// Spying on Music
+	BOOL musicIsPlaying;
 	BOOL jiggleConditionsLikelyToHaveChanged;
 	
 	// Status bar icon variants

--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -93,9 +93,9 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 	[runLoop addTimer:jiggleTimer forMode:NSModalPanelRunLoopMode];
 	[runLoop addTimer:jiggleTimer forMode:NSEventTrackingRunLoopMode];
 	
-	// Watch iTunes
-	[[NSDistributedNotificationCenter defaultCenter] addObserver:self selector:@selector(iTunesChanged:) name:@"com.apple.iTunes.playerInfo" object:nil];
-	iTunesIsPlaying = [self iTunesIsPlayingNow];
+	// Watch Music
+	[[NSDistributedNotificationCenter defaultCenter] addObserver:self selector:@selector(musicChanged:) name:@"com.apple.Music.playerInfo" object:nil];
+	musicIsPlaying = [self musicIsPlayingNow];
 	
 	// Watch Workspace
 	[[[NSWorkspace sharedWorkspace] notificationCenter] addObserver:self selector:@selector(applicationListChanged:) name:NSWorkspaceDidLaunchApplicationNotification object:nil];
@@ -443,12 +443,12 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 		return NO;
 }
 
-- (BOOL)iTunesIsRunningNow
+- (BOOL)musicIsRunningNow
 {
 	NSWorkspace *ws = [NSWorkspace sharedWorkspace];
 	NSArray *runningApps = [ws runningApplications];
 	int i, c;
-	BOOL iTunesIsRunning = NO;
+	BOOL musicIsRunning = NO;
 	
 	for (i = 0, c = (int)[runningApps count]; i < c; ++i)
 	{
@@ -458,26 +458,26 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 		
 		NSLog(@"index %d: name %@ bundle id %@", i, runningAppLocalizedName, runningAppBundleIdentifier);
 		
-		if ([runningAppLocalizedName isEqualToString:@"iTunes"] || [runningAppBundleIdentifier isEqualToString:@"com.apple.iTunes"])
+		if ([runningAppLocalizedName isEqualToString:@"Music"] || [runningAppBundleIdentifier isEqualToString:@"com.apple.Music"])
 		{
-			iTunesIsRunning = YES;
+			musicIsRunning = YES;
 			break;
 		}
 	}
 	
-	return iTunesIsRunning;
+	return musicIsRunning;
 }
 
-- (BOOL)iTunesIsPlayingNow
+- (BOOL)musicIsPlayingNow
 {
-	if ([self iTunesIsRunningNow])
+	if ([self musicIsRunningNow])
 	{
-		NSAppleScript *iTunesScript = [[NSAppleScript alloc] initWithSource:@"tell application \"iTunes\"\nget player state\nend tell"];
+		NSAppleScript *musicScript = [[NSAppleScript alloc] initWithSource:@"tell application \"Music\"\nget player state\nend tell"];
 		NSDictionary *errorDict = nil;
 		NSAppleEventDescriptor *returnDesc = nil;
 		
-		returnDesc = [iTunesScript executeAndReturnError:&errorDict];
-		[iTunesScript autorelease];
+		returnDesc = [musicScript executeAndReturnError:&errorDict];
+		[musicScript autorelease];
 		
 		return [[returnDesc stringValue] isEqualToString:@"kPSP"];
 	}
@@ -531,10 +531,10 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 	NSArray *applicationNameComponents = [prefs applicationNameComponents];
     BOOL mustBeDockApp = ([prefs onlyWithIdentityTag] == 0);    // 0 means the user wants apps only, 1 means any process
 	BOOL onlyWithApplicationsNamedX = ([prefs onlyWithApplicationsNamedX] && [applicationNameComponents count]);
-	BOOL onlyWithITunesPlaying = [prefs onlyWithITunesPlaying];
+	BOOL onlyWithMusicPlaying = [prefs onlyWithMusicPlaying];
 	
 	// If no conditions are set, then the conditions are met
-	if (!onlyWithCPUUsage && !onlyWithRemovableWritableDisks && !onlyWithApplicationsNamedX && !onlyWithITunesPlaying)
+	if (!onlyWithCPUUsage && !onlyWithRemovableWritableDisks && !onlyWithApplicationsNamedX && !onlyWithMusicPlaying)
     {
 		return YES;
 	}
@@ -555,9 +555,9 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
         NSLog(@"jiggleConditionsMet: cpu usage is high");
 		return YES;
 	}
-	if (onlyWithITunesPlaying && ([self iTunesIsRunningNow] && iTunesIsPlaying))
+	if (onlyWithMusicPlaying && ([self musicIsRunningNow] && musicIsPlaying))
     {
-        NSLog(@"jiggleConditionsMet: iTunes is playing");
+        NSLog(@"jiggleConditionsMet: Music is playing");
 		return YES;
 	}
 	
@@ -781,18 +781,18 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 
 #endif
 
-- (void)iTunesChanged:(NSNotification *)note
+- (void)musicChanged:(NSNotification *)note
 {
 	NSDictionary *ui = [note userInfo];
 	NSString *playerState = [ui objectForKey:@"Player State"];
 	
-	iTunesIsPlaying = (playerState && [playerState isEqualToString:@"Playing"]);
+	musicIsPlaying = (playerState && [playerState isEqualToString:@"Playing"]);
 	jiggleConditionsLikelyToHaveChanged = YES;
 	
 	// Bump our jiggle code for immediate action if appropriate
 	[self periodicJiggleStatusCheck:nil];
 	
-	NSLog(@"iTunesChanged:");
+	NSLog(@"musicChanged:");
 }
 
 - (void)applicationListChanged:(NSNotification *)note

--- a/Base.lproj/Preferences.xib
+++ b/Base.lproj/Preferences.xib
@@ -24,7 +24,7 @@
                 <outlet property="notWithFrontAppsNamedXCheckbox" destination="713" id="744"/>
                 <outlet property="onlyWithApplicationsNamedXCheckbox" destination="686" id="722"/>
                 <outlet property="onlyWithCPUUsageCheckbox" destination="682" id="723"/>
-                <outlet property="onlyWithITunesPlayingCheckbox" destination="692" id="724"/>
+                <outlet property="onlyWithMusicPlayingCheckbox" destination="692" id="724"/>
                 <outlet property="onlyWithIdentityPopUp" destination="700" id="725"/>
                 <outlet property="onlyWithRemovableWritableDisksCheckbox" destination="684" id="726"/>
                 <outlet property="preferencesWindow" destination="654" id="727"/>
@@ -299,12 +299,12 @@
                     <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="692">
                         <rect key="frame" x="40" y="276" width="390" height="18"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <buttonCell key="cell" type="check" title="iTunes is currently playing music (not paused or stopped)" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="693">
+                        <buttonCell key="cell" type="check" title="Music is currently playing (not paused or stopped)" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="693">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                         <connections>
-                            <action selector="onlyWithITunesPlayingChanged:" target="-2" id="738"/>
+                            <action selector="onlyWithMusicPlayingChanged:" target="-2" id="738"/>
                         </connections>
                     </button>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="694">

--- a/PrefsController.h
+++ b/PrefsController.h
@@ -32,7 +32,7 @@
     
 	IBOutlet NSButton *onlyWithRemovableWritableDisksCheckbox;
     
-	IBOutlet NSButton *onlyWithITunesPlayingCheckbox;
+	IBOutlet NSButton *onlyWithMusicPlayingCheckbox;
     
 	IBOutlet NSButton *onlyWithApplicationsNamedXCheckbox;
     IBOutlet NSPopUpButton *onlyWithIdentityPopUp;
@@ -58,7 +58,7 @@
     
     BOOL onlyWithRemovableWritableDisks;
     
-    BOOL onlyWithITunesPlaying;
+    BOOL onlyWithMusicPlaying;
     
     BOOL onlyWithApplicationsNamedX;
     int onlyWithIdentityTag;
@@ -92,7 +92,7 @@
 
 - (BOOL)onlyWithRemovableWritableDisks;
 
-- (BOOL)onlyWithITunesPlaying;
+- (BOOL)onlyWithMusicPlaying;
 
 - (BOOL)onlyWithApplicationsNamedX;
 - (int)onlyWithIdentityTag;                 // 0 == app, 1 == process
@@ -118,7 +118,7 @@
 
 - (IBAction)onlyWithRemovableWritableDisksChanged:(id)sender;
 
-- (IBAction)onlyWithITunesPlayingChanged:(id)sender;
+- (IBAction)onlyWithMusicPlayingChanged:(id)sender;
 
 - (IBAction)onlyWithIdentityPopUpChanged:(id)sender;
 - (IBAction)onlyWithApplicationsNamedXChanged:(id)sender;

--- a/PrefsController.m
+++ b/PrefsController.m
@@ -24,7 +24,7 @@ static NSString *JiggleDistanceDefaultsKey = @"JiggleDistance";
 static NSString *OnlyWithCPUUsageDefaultsKey = @"OnlyWithCPUUsage";
 static NSString *CPUUsageThresholdDefaultsKey = @"CPUUsageThreshold";
 static NSString *OnlyWithRemovableWritableDisksDefaultsKey = @"OnlyWithRemovableWritableDisks";
-static NSString *OnlyWithITunesPlayingDefaultsKey = @"OnlyWithITunesPlaying";
+static NSString *OnlyWithMusicPlayingDefaultsKey = @"OnlyWithITunesPlaying";	// historical key name retained for backwards compatibility with stored prefs
 static NSString *OnlyWithApplicationsNamedXDefaultsKey = @"OnlyWithApplicationsNamedX";
 static NSString *OnlyWithIdentityDefaultsKey = @"OnlyWithIdentity";
 static NSString *ApplicationNameComponentDefaultsKey = @"ApplicationNameComponent";
@@ -70,7 +70,7 @@ static PrefsController *sharedPrefsController = nil;
                                             
                                             @"NO", OnlyWithRemovableWritableDisksDefaultsKey,
                                             
-                                            @"NO", OnlyWithITunesPlayingDefaultsKey,
+                                            @"NO", OnlyWithMusicPlayingDefaultsKey,
                                             
                                             @"NO", OnlyWithApplicationsNamedXDefaultsKey,
                                             [NSNumber numberWithInt:0], OnlyWithIdentityDefaultsKey,
@@ -128,7 +128,7 @@ static PrefsController *sharedPrefsController = nil;
             
 			onlyWithRemovableWritableDisks = [userDefaults boolForKey:OnlyWithRemovableWritableDisksDefaultsKey];
             
-			onlyWithITunesPlaying = [userDefaults boolForKey:OnlyWithITunesPlayingDefaultsKey];
+			onlyWithMusicPlaying = [userDefaults boolForKey:OnlyWithMusicPlayingDefaultsKey];
             
 			onlyWithApplicationsNamedX = [userDefaults boolForKey:OnlyWithApplicationsNamedXDefaultsKey];
             onlyWithIdentityTag = (int)[userDefaults integerForKey:OnlyWithIdentityDefaultsKey];
@@ -213,7 +213,7 @@ static PrefsController *sharedPrefsController = nil;
 		
 		[onlyWithRemovableWritableDisksCheckbox setState:onlyWithRemovableWritableDisks];
         
-		[onlyWithITunesPlayingCheckbox setState:onlyWithITunesPlaying];
+		[onlyWithMusicPlayingCheckbox setState:onlyWithMusicPlaying];
         
 		[onlyWithApplicationsNamedXCheckbox setState:(onlyWithApplicationsNamedX && [applicationNameComponent length])];
         [onlyWithIdentityPopUp selectItemWithTag:onlyWithIdentityTag];
@@ -283,9 +283,9 @@ static PrefsController *sharedPrefsController = nil;
 	return onlyWithRemovableWritableDisks;
 }
 
-- (BOOL)onlyWithITunesPlaying
+- (BOOL)onlyWithMusicPlaying
 {
-	return onlyWithITunesPlaying;
+	return onlyWithMusicPlaying;
 }
 
 - (BOOL)onlyWithApplicationsNamedX
@@ -472,14 +472,14 @@ static PrefsController *sharedPrefsController = nil;
 	}
 }
 
-- (IBAction)onlyWithITunesPlayingChanged:(id)sender
+- (IBAction)onlyWithMusicPlayingChanged:(id)sender
 {
 	BOOL newState = [sender state];
 	
-	if (newState != onlyWithITunesPlaying)
+	if (newState != onlyWithMusicPlaying)
 	{
-		onlyWithITunesPlaying = newState;
-		[[NSUserDefaults standardUserDefaults] setBool:newState forKey:OnlyWithITunesPlayingDefaultsKey];
+		onlyWithMusicPlaying = newState;
+		[[NSUserDefaults standardUserDefaults] setBool:newState forKey:OnlyWithMusicPlayingDefaultsKey];
 	}
 }
 


### PR DESCRIPTION
Fixes #40.

iTunes was renamed to Music in macOS 10.15, which is Jiggler's minimum deployment target (`MACOSX_DEPLOYMENT_TARGET = 10.15`), so iTunes is never present on any supported version. The previous code was sending AppleEvents to `iTunes`, registering for `com.apple.iTunes.playerInfo`, and matching the running-app bundle id `com.apple.iTunes`, none of which can succeed.

## Changes

- `AppDelegate.m`
  - Distributed notification subscription: `com.apple.iTunes.playerInfo` → `com.apple.Music.playerInfo`
  - Running-app match: localized name `iTunes`/bundle id `com.apple.iTunes` → `Music`/`com.apple.Music`
  - AppleScript target: `tell application "iTunes"` → `tell application "Music"`
  - Updated related log lines and comments
- Renamed internal symbols for consistency: `iTunesIsPlaying`, `iTunesIsRunningNow`, `iTunesIsPlayingNow`, `iTunesChanged:`, `onlyWithITunesPlaying`, `onlyWithITunesPlayingCheckbox`, `onlyWithITunesPlayingChanged:`, `OnlyWithITunesPlayingDefaultsKey` (C identifier only) → `music…` / `Music…` equivalents.
- `Base.lproj/Preferences.xib`: button title `iTunes is currently playing music…` → `Music is currently playing…`, plus matching outlet/action names.

## Backwards compatibility

The `NSUserDefaults` key string literal is **deliberately left** as `@"OnlyWithITunesPlaying"` (only the C identifier is renamed), so existing users' stored preferences continue to be honoured. A comment notes this.

## Notes

- The AppleScript `player state` property still returns the `kPSP` four-char code for "playing" in Music.app — no change needed there.
- No new dependencies. Same deployment target.