### PR TITLE
Restore previously-removed activity assertions (fixes #44, likely fixes #43)

### DIFF
--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -246,10 +246,20 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
         CFSTR("Jiggler Zen Jiggle Activity"),
         &_userActivityAssertion
     );
-	
+
     if (result != kIOReturnSuccess) {
         NSLog(@"[Jiggler] Failed to declare user activity (IOReturn = 0x%x)", result);
     }
+
+	// Also call IOPMAssertionDeclareUserActivity().  This is a separate, self-managing API
+	// from IOPMAssertionCreateWithName(); each one signals activity to different layers of
+	// the system, so we call both to maximise coverage (see issue #44 / #43).  The assertion
+	// ID is reused across calls; Apple's API refreshes the timestamp internally.
+	static IOPMAssertionID userActivityDeclaration = kIOPMNullAssertionID;
+	IOReturn declareResult = IOPMAssertionDeclareUserActivity(CFSTR("Jiggler"), kIOPMUserActiveLocal, &userActivityDeclaration);
+	if (declareResult != kIOReturnSuccess) {
+		NSLog(@"[Jiggler] IOPMAssertionDeclareUserActivity failed (IOReturn = 0x%x)", declareResult);
+	}
 }
 
 - (BOOL)isInAScreen:(NSPoint)point
@@ -677,6 +687,34 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 				{
 					// Zen jiggle: skip actually moving the mouse.  Of course some apps watch the cursor position rather
 					// than looking at the system idle time, so Zen jiggle may fail to jiggle some apps; caveat jigglor...
+
+					// On macOS 15 and later, also post a no-move mouse event to reset idle time without visible motion.
+					// This is one of several activity signals we emit in parallel; see issue #44.
+					if (@available(macOS 15.0, *))
+					{
+						NSPoint mouseLocation = [NSEvent mouseLocation];
+						NSScreen *primaryScreen = [NSScreen primaryScreen];
+						NSRect screenFrame = [primaryScreen frame];
+						CGPoint cgMouseLocation;
+
+						cgMouseLocation.x = mouseLocation.x;
+						cgMouseLocation.y = screenFrame.size.height - mouseLocation.y;
+
+						CGEventSourceRef sourceRef = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
+						if (sourceRef)
+						{
+							CFTimeInterval oldSuppressionInterval = CGEventSourceGetLocalEventsSuppressionInterval(sourceRef);
+							CGEventSourceSetLocalEventsSuppressionInterval(sourceRef, 0.0);
+							CGEventRef eventMoved = CGEventCreateMouseEvent(sourceRef, kCGEventMouseMoved, cgMouseLocation, kCGMouseButtonLeft);
+							if (eventMoved)
+							{
+								CGEventPost(kCGHIDEventTap, eventMoved);
+								CFRelease(eventMoved);
+							}
+							CGEventSourceSetLocalEventsSuppressionInterval(sourceRef, oldSuppressionInterval);
+							CFRelease(sourceRef);
+						}
+					}
 				}
 				else if (jiggleStyle == 2)
 				{


### PR DESCRIPTION
Fixes #44. Likely also fixes #43 (Teams not staying awake under Zen jiggle).

Per the maintainer's own note on #44:

> In commit e9ef994 the issue with Zen jiggle was fixed by shifting to a different way of asserting activity. Two older ways of asserting activity were removed in that commit. I think those two older ways should be added back in… It's best to indicate activity in all possible ways, for maximum coverage.

This PR restores those two signals while keeping the new `IOPMAssertionCreateWithName(kIOPMAssertionTypePreventUserIdleDisplaySleep, …)` assertion that fixed Zen jiggle.

## What's restored

1. **`IOPMAssertionDeclareUserActivity(CFSTR("Jiggler"), kIOPMUserActiveLocal, &id)`** — added back inside `-declareUserActivity`, alongside the new assertion. This is a separate, self-managing API; the assertion ID is reused across calls and refreshed internally by the OS.
2. **No-move `CGEventMouseMoved` post (macOS 15+)** — restored in the `jiggleStyle == 1` (Zen jiggle) branch of `-periodicJiggleStatusCheck:`. Suppression interval is saved/restored as before.

The various activity-signalling APIs target different layers of macOS's idle tracking, so emitting all of them in parallel maximises the chance that any given app (Teams, etc.) sees the signal it cares about.

## Hardening

The no-move `CGEventMouseMoved` block now NULL-checks `CGEventCreateMouseEvent` before posting, matching the defensive style used in the click-jiggle branch a few lines below.

## Notes

- No change to the dedicated `-declareUserActivity` / `-undeclareUserActivity` lifecycle, so behaviour around state changes (e.g. `setJigglingActive:NO` releasing the assertion) is unchanged.
- `UpdateSystemActivity(UsrActivity)` (already present, kept in the existing code) continues to run; this PR is purely additive on top of that.