### PR TITLE
Detect denied Accessibility access on macOS 15+ (fixes #48)

### DIFF
--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -130,23 +130,42 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 	jiggleMasterSwitch = [userDefaults boolForKey:JiggleMasterSwitchDefaultsKey];
 	[self fixMasterSwitchUI];
 	
-	// Check that we have the Accessibility access we need; see https://stackoverflow.com/a/53617674/2752221
+	// Check that we have the Accessibility access we need.
+	//
+	// Why this matters: without Accessibility, CGEventPost silently becomes a no-op
+	// on modern macOS.  Jiggler then launches normally, shows its menu-bar icon,
+	// marks itself as actively jiggling, and yet every synthetic mouse-move / click
+	// vanishes into the void — the system still goes to sleep.  Exactly the
+	// regression reported on Tahoe 26.5 (issue #48): the OS upgrade re-prompts
+	// for TCC permissions, and Jiggler, never having surfaced the resulting denial,
+	// looks like it is working but isn't.
+	//
+	// On macOS 15+ we register with TCC via the no-prompt check (so we appear in
+	// System Settings without an annoying prompt on every launch), then verify the
+	// result and run the same alert + open-settings + quit flow as the legacy path.
+	BOOL accessibilityTrusted;
+
 	if (@available(macOS 15.0, *))
 	{
 		NSDictionary *opts = [NSDictionary dictionaryWithObjectsAndKeys:(id)kCFBooleanFalse, (id)kAXTrustedCheckOptionPrompt, nil];
-		(void)AXIsProcessTrustedWithOptions((CFDictionaryRef)opts);
+		accessibilityTrusted = AXIsProcessTrustedWithOptions((CFDictionaryRef)opts);
 	}
-	else if (!AXIsProcessTrusted())
+	else
 	{
-		NSModalResponse retval = SSRunCriticalAlertPanel(@"Turn on accessibility", @"Jiggler needs to control the mouse cursor to function.  To enable this capability, please select the Jiggler checkbox in Security & Privacy > Accessibility, and then restart Jiggler (which will quit now).", @"Turn On Accessibility", @"Quit", nil);
-		
+		accessibilityTrusted = AXIsProcessTrusted();
+	}
+
+	if (!accessibilityTrusted)
+	{
+		NSModalResponse retval = SSRunCriticalAlertPanel(@"Turn on accessibility", @"Jiggler needs to control the mouse and keyboard to function.  To enable this capability, please select the Jiggler checkbox in System Settings > Privacy & Security > Accessibility, and then restart Jiggler (which will quit now).", @"Turn On Accessibility", @"Quit", nil);
+
 		if (retval == NSAlertFirstButtonReturn)
 		{
 			NSString *prefPage = @"x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
-			
+
 			[[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:prefPage]];
 		}
-		
+
 		[NSApp terminate:nil];
 	}
 	


### PR DESCRIPTION
Fixes #48. Probably also explains a chunk of the other "v1.10 stopped working on Tahoe" reports.

## Root cause

The macOS-15+ branch of the launch-time Accessibility check casts the result of `AXIsProcessTrustedWithOptions()` to `void` and moves on:

```objc
if (@available(macOS 15.0, *)) {
    NSDictionary *opts = [NSDictionary dictionaryWithObjectsAndKeys:(id)kCFBooleanFalse, (id)kAXTrustedCheckOptionPrompt, nil];
    (void)AXIsProcessTrustedWithOptions((CFDictionaryRef)opts);   // result discarded
}
else if (!AXIsProcessTrusted()) {
    // critical alert + open Settings + terminate
}
```

The intent is clearly to register with TCC via the no-prompt variant so the app appears in System Settings without nagging on every launch — but the failure mode after major OS upgrades is bad:

1. **Tahoe 26.5** (or another upgrade that resets/re-prompts TCC).
2. User has not yet re-granted (or actively denied) Accessibility for Jiggler.
3. Jiggler launches normally, the menu-bar icon turns green when it thinks it is jiggling, but **every `CGEventPost` is silently dropped** because the process is not Accessibility-trusted on modern macOS.
4. The Mac still goes to sleep / runs the screensaver.

That matches the user-visible symptom in #48 ("Jiggler appears to run … Mac still goes to sleep") exactly.

## Fix

Unify the trust check: the 15+ branch now captures the boolean result of `AXIsProcessTrustedWithOptions()` (no-prompt behaviour preserved — we still pass `kAXTrustedCheckOptionPrompt = false`). Both version branches feed into the same `if (!accessibilityTrusted) { … alert … open Settings … terminate; }` block.

Wording of the alert is also touched:
- "Security & Privacy" → "System Settings > Privacy & Security" (modern pane name)
- "the mouse cursor" → "the mouse and keyboard" (keyboard events are synthesised in some modes too)

## Verification

`xcodebuild -configuration Debug build` → `BUILD SUCCEEDED`, no warnings. Smoke-tested on macOS 26.4.1: my DerivedData build path is not Accessibility-trusted, so the new check correctly catches the denial and fires the alert + terminate (unified log shows `NSAccessibility Request Received` → `terminate:` ~130 ms later). In production a user sees the alert and is deep-linked into the right Settings pane.

## Repro path for testers

After installing this build, once: remove Jiggler from **System Settings > Privacy & Security > Accessibility**, then launch Jiggler. Should now show the alert and open Settings, instead of silently lying about jiggling.