### PR TITLE
Make overlay click-through during click-jiggle (fixes #18)

### DIFF
--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -695,10 +695,20 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 					
                     if (click_down && click_up)
                     {
+                        // Issue #18: if the user has parked the cursor on the overlay window, our
+                        // synthetic click would otherwise be absorbed by the overlay (which is
+                        // interactive so it can be drag-repositioned).  Make it click-through for
+                        // the duration of the click, then restore.  No-op if the overlay does not
+                        // exist (user has the on-screen icon disabled).
+                        BOOL overlayWasInteractive = ![JigglerOverlayWindow setOverlayIgnoresMouseEvents:YES];
+
                         CGEventPost(kCGHIDEventTap, click_down);
                         usleep(10000);
                         CGEventPost(kCGHIDEventTap, click_up);
-                        
+
+                        if (overlayWasInteractive)
+                            [JigglerOverlayWindow setOverlayIgnoresMouseEvents:NO];
+
                         CFRelease(click_down);
                         CFRelease(click_up);
                     }

--- a/JigglerOverlayWindow.h
+++ b/JigglerOverlayWindow.h
@@ -22,4 +22,12 @@
 
 + (BOOL)isActivated;
 
+// Toggle whether the overlay window passes mouse events through to whatever
+// is behind it.  Used by the click-jiggle path so that a synthetic click
+// delivered at the cursor location does not get absorbed by the overlay if
+// the user has parked the cursor on top of it (issue #18).  Returns the
+// previous flag value so callers can restore it.  No-op (returns NO) when
+// the overlay window has not been created yet.
++ (BOOL)setOverlayIgnoresMouseEvents:(BOOL)flag;
+
 @end

--- a/JigglerOverlayWindow.m
+++ b/JigglerOverlayWindow.m
@@ -50,8 +50,21 @@ static NSString *JigglerOverlayVerticalPositionDefaultsKey = @"OverlayVerticalPo
 + (BOOL)isActivated
 {
 	JigglerOverlayWindow *sharedOverlay = [JigglerOverlayWindow sharedOverlayWindow];
-	
+
 	return [sharedOverlay isActivated];
+}
+
++ (BOOL)setOverlayIgnoresMouseEvents:(BOOL)flag
+{
+	JigglerOverlayWindow *sharedOverlay = [JigglerOverlayWindow sharedOverlayWindow];
+	NSWindow *win = sharedOverlay->overlayWindow;
+
+	if (!win)
+		return NO;
+
+	BOOL previous = [win ignoresMouseEvents];
+	[win setIgnoresMouseEvents:flag];
+	return previous;
 }
 
 + (JigglerOverlayWindow *)sharedOverlayWindow


### PR DESCRIPTION
Fixes #18 — "click-mode Jiggler doesn't work if mouse is above the icon".

## Bug

Click-jiggle posts a synthetic click at the current cursor location. If the user has parked the cursor on top of the on-screen overlay window, the overlay (which is interactive so it can be drag-repositioned) absorbs the click and the application underneath never sees anything. Reported by @sxflynn: a VM logged the user out after 20 minutes of supposed activity because every click hit the overlay instead of the VM.

The thread on the issue ended with "I'd suggest just turning the icon off" as a workaround, and "I'll keep this issue open for the suggestion of having the icon move to avoid the mouse, but that's unlikely to happen soon." — this PR offers a third option that doesn't require dropping either feature.

## Fix

The overlay can't be made permanently click-through without losing the drag-to-reposition feature. So we toggle `ignoresMouseEvents` *only* around the synthetic mouse-down + sleep + mouse-up sequence, then restore it:

```objc
BOOL overlayWasInteractive = ![JigglerOverlayWindow setOverlayIgnoresMouseEvents:YES];

CGEventPost(kCGHIDEventTap, click_down);
usleep(10000);
CGEventPost(kCGHIDEventTap, click_up);

if (overlayWasInteractive)
    [JigglerOverlayWindow setOverlayIgnoresMouseEvents:NO];
```

The window is interactive at all other times, so dragging it still works. The race window where a user actively drags the overlay *and* a click-jiggle fires in the same ~10 ms is theoretically possible but absurd in practice.

## New API

```objc
+ (BOOL)setOverlayIgnoresMouseEvents:(BOOL)flag;   // returns previous value; no-op (returns NO) when overlay window doesn't exist yet
```

Added to `JigglerOverlayWindow`. Encapsulates the access to the internal `overlayWindow` ivar so the caller in AppDelegate doesn't reach across the class.

## Verification

Builds clean (`xcodebuild -configuration Debug build` → BUILD SUCCEEDED, no warnings). Smoke-test launches alive.