### PR TITLE
Lower the standard-jiggle minimum distance from 10 px to 2 px (fixes #43)

### DIFF
--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -312,7 +312,10 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 	// Figure out the distance scale we want to move over
 	int baseTolerance = [[PrefsController sharedPrefsController] jiggleDistance];
 	
-	if (baseTolerance < 10) baseTolerance = 10;
+	// Floor matches the "+ 2" in -[PrefsController jiggleDistance] (issue #43); the
+	// ceiling is the upper end of the quadratic (20² + 2 == 402, rounded to 410 for
+	// headroom against any future tweaks to the curve).
+	if (baseTolerance < 2) baseTolerance = 2;
 	if (baseTolerance > 410) baseTolerance = 410;
 	
 	// Find a suitable new mouse location.  A suitable location is sufficiently close to the last seen user-set mouse

--- a/PrefsController.m
+++ b/PrefsController.m
@@ -265,7 +265,12 @@ static PrefsController *sharedPrefsController = nil;
 
 - (int)jiggleDistance
 {
-	return (int)(jiggleDistance * jiggleDistance + 10);
+	// Slider is 0..20 (float); we return a pixel tolerance that grows quadratically.
+	// The "+ 2" floor used to be "+ 10", but users running activity-sensitive apps
+	// (Teams, Slack) asked for a smaller minimum so the cursor barely moves while
+	// still registering as motion (issue #43).  Quadratic shape keeps fine control
+	// at low slider values and large reach at high values.
+	return (int)(jiggleDistance * jiggleDistance + 2);
 }
 
 - (BOOL)onlyWithCPUUsage


### PR DESCRIPTION
Fixes #43.

Microsoft Teams and Slack on modern macOS don't trust the system idle timer alone for the Available/Away switch — they also hook on real mouse-move events. Activity assertions (#44 etc.) keep the OS awake but don't fool those apps. The remaining knob for users in that situation is the standard-jiggle distance, and its current floor is **10 px** (slider value 0 mapped to 0² + 10 = 10 in `-[PrefsController jiggleDistance]`). That is more cursor wiggle than people want for a long-running background jiggle they don't notice.

## Fix

Drop the floor to 2 px. Curve is now `x² + 2`:

| Slider | Before | After |
|---|---:|---:|
| 0 | 10 px | **2 px** |
| 1 | 11 px | 3 px |
| 5 | 35 px | 27 px |
| 10 | 110 px | 102 px |
| 20 | 410 px | 402 px (clamped to 410) |

2 px is small enough to be barely noticeable but still registers as motion in the apps that care. The matching safety floor in `-periodicJiggleStatusCheck:` is lowered to match. The slider UI itself is unchanged — the value space at the high end is essentially identical, only the low end becomes finer-grained.

## Why minimal

Tried to keep this strictly scoped to the floor change so it can land without dragging in anything else. No new pref, no UI change, no migration concern (the slider value persisted in defaults still maps to the new curve cleanly — users who had it at 0 will now get 2 px instead of 10 px, which is what the issue is asking for).

## Verification

`xcodebuild -configuration Debug build` → BUILD SUCCEEDED, no warnings. Smoke-test alive.