### PR TITLE
Three hidden defaults knobs (refs #2, #19, #28)

### DIFF
--- a/AppDelegate.h
+++ b/AppDelegate.h
@@ -47,6 +47,11 @@
 @property (retain) IBOutlet NSMenuItem *timedQuitItem;
 @property (retain) NSStatusItem *statusItem;
 
+// Programmatic entry point for the timed-quit timer (used by -timedQuit: after the
+// user confirms via the modal panel, and by the launch-time hidden pref
+// TimedQuitAtLaunchMinutes; see issue #19).
+- (void)startTimedQuitWithMinutes:(int)minutes;
+
 - (IBAction)showAbout:(id)sender;
 - (IBAction)showReadMe:(id)sender;
 - (IBAction)showProductHomePage:(id)sender;

--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -153,6 +153,38 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 	// Prevent app nap; see https://lapcatsoftware.com/articles/prevent-app-nap.html
     activityToken = [[NSProcessInfo processInfo] beginActivityWithOptions:NSActivityUserInitiatedAllowingIdleSystemSleep reason:@"No napping on the job!"];
 	[activityToken retain];
+
+	// Issue #19: hidden opt-in to start Timed Quit automatically on launch.
+	// Enable with:  defaults write com.stick.app.jiggler TimedQuitAtLaunchMinutes -int 240
+	// (240 = 4 hours; any positive integer in minutes works.)  Set to 0 or remove
+	// the key to disable.  No Preferences UI exposed — power-user knob.
+	NSInteger launchMinutes = [userDefaults integerForKey:@"TimedQuitAtLaunchMinutes"];
+	if (launchMinutes > 0)
+		[self startTimedQuitWithMinutes:(int)launchMinutes];
+
+	// Issue #2 (sub-bullet "after time has passed"): hidden opt-in to flip the
+	// master switch OFF after N minutes from launch, without quitting the app.
+	// Useful as a "stop jiggling at the end of the work day" knob.  Different
+	// from TimedQuitAtLaunchMinutes above in that the app keeps running and the
+	// user can re-enable from the menu.
+	//
+	//   defaults write com.stick.app.jiggler DisableAfterMinutes -int 480   # 8h
+	NSInteger disableAfter = [userDefaults integerForKey:@"DisableAfterMinutes"];
+	if (disableAfter > 0)
+	{
+		__block __weak typeof(self) weakSelf = self;
+		dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(disableAfter * 60.0 * NSEC_PER_SEC)),
+					   dispatch_get_main_queue(), ^{
+			__strong typeof(self) strongSelf = weakSelf;
+			if (!strongSelf || !strongSelf->jiggleMasterSwitch)
+				return;	// gone, or already off
+
+			strongSelf->jiggleMasterSwitch = NO;
+			[[NSUserDefaults standardUserDefaults] setBool:NO forKey:JiggleMasterSwitchDefaultsKey];
+			[strongSelf fixMasterSwitchUI];
+			[strongSelf fixStatusItemIcon];
+		});
+	}
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification
@@ -685,33 +717,77 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 					NSScreen *primaryScreen = [NSScreen primaryScreen];
 					NSRect screenFrame = [primaryScreen frame];
 					CGPoint cgMouseLocation;
-					
+
 					cgMouseLocation.x = mouseLocation.x;
 					cgMouseLocation.y = screenFrame.size.height - mouseLocation.y;
-					
+
 					// Create and post the mouse-down and mouse-up events
 					CGEventRef click_down = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseDown, cgMouseLocation, kCGMouseButtonLeft);
 					CGEventRef click_up = CGEventCreateMouseEvent(NULL, kCGEventLeftMouseUp, cgMouseLocation, kCGMouseButtonLeft);
-					
+
                     if (click_down && click_up)
                     {
                         CGEventPost(kCGHIDEventTap, click_down);
                         usleep(10000);
                         CGEventPost(kCGHIDEventTap, click_up);
-                        
+
                         CFRelease(click_down);
                         CFRelease(click_up);
                     }
                     else
                     {
                         static bool beenHere = false;
-                        
+
                         if (!beenHere)
                         {
                             NSLog(@"Jiggler was unable to create mouse click events.");
                             beenHere = true;
                         }
                     }
+				}
+				else if (jiggleStyle == 3)
+				{
+					// Keystroke jiggle (issue #28): post a no-op keystroke instead of moving
+					// or clicking the mouse.  Useful for remote-desktop sessions, where mouse
+					// activity on the local machine does not register at the remote side, and
+					// for users who don't want click-jiggle's "click wherever the cursor is"
+					// behaviour.  Hidden feature, no Preferences UI; enable with:
+					//
+					//   defaults write com.stick.app.jiggler JiggleStyle -int 3
+					//
+					// Default key is F2 (key code 120), chosen because virtually nothing reacts
+					// to it.  Override with:
+					//
+					//   defaults write com.stick.app.jiggler JiggleKeystrokeKeyCode -int <code>
+					NSInteger keyCode = [[NSUserDefaults standardUserDefaults] integerForKey:@"JiggleKeystrokeKeyCode"];
+					if (keyCode <= 0) keyCode = 120;	// F2
+
+					CGEventSourceRef sourceRef = CGEventSourceCreate(kCGEventSourceStateHIDSystemState);
+					if (sourceRef)
+					{
+						CGEventRef keyDown = CGEventCreateKeyboardEvent(sourceRef, (CGKeyCode)keyCode, true);
+						CGEventRef keyUp   = CGEventCreateKeyboardEvent(sourceRef, (CGKeyCode)keyCode, false);
+
+						if (keyDown && keyUp)
+						{
+							CGEventPost(kCGHIDEventTap, keyDown);
+							usleep(10000);
+							CGEventPost(kCGHIDEventTap, keyUp);
+						}
+						else
+						{
+							static bool beenHere = false;
+							if (!beenHere)
+							{
+								NSLog(@"Jiggler was unable to create keystroke events.");
+								beenHere = true;
+							}
+						}
+
+						if (keyDown) CFRelease(keyDown);
+						if (keyUp)   CFRelease(keyUp);
+						CFRelease(sourceRef);
+					}
 				}
 				else	// jiggleStyle == 0, and bad values
 				{
@@ -904,22 +980,27 @@ extern OSErr UpdateSystemActivity(UInt8 activity) __attribute__((weak_import));
 		[NSApp performSelector:@selector(terminate:) withObject:nil afterDelay:0.5 inModes:@[NSDefaultRunLoopMode]];
 }
 
+- (void)startTimedQuitWithMinutes:(int)minutes
+{
+	if (minutes <= 0)
+		return;
+
+	minutesRemainingToTimedQuit = minutes;
+
+	NSRunLoop *runLoop = [NSRunLoop currentRunLoop];
+
+	timedQuitTimer = [NSTimer timerWithTimeInterval:60.0 target:self selector:@selector(_timedQuitTimer:) userInfo:nil repeats:YES];
+	[runLoop addTimer:timedQuitTimer forMode:NSRunLoopCommonModes];
+	[runLoop addTimer:timedQuitTimer forMode:NSModalPanelRunLoopMode];		// not clear whether this is part of NSRunLoopCommonModes...
+	[runLoop addTimer:timedQuitTimer forMode:NSEventTrackingRunLoopMode];	// not clear whether this is part of NSRunLoopCommonModes...
+
+	[self fixTimedQuitMenuItem];
+	[self fixStatusItemIcon];
+}
+
 - (IBAction)timedQuit:(id)sender
 {
-	minutesRemainingToTimedQuit = [TimedQuitController runPanelForMinutesUntilQuit];
-	
-	if (minutesRemainingToTimedQuit)
-	{
-		NSRunLoop *runLoop = [NSRunLoop currentRunLoop];
-		
-		timedQuitTimer = [NSTimer timerWithTimeInterval:60.0 target:self selector:@selector(_timedQuitTimer:) userInfo:nil repeats:YES];
-		[runLoop addTimer:timedQuitTimer forMode:NSRunLoopCommonModes];
-		[runLoop addTimer:timedQuitTimer forMode:NSModalPanelRunLoopMode];		// not clear whether this is part of NSRunLoopCommonModes...
-		[runLoop addTimer:timedQuitTimer forMode:NSEventTrackingRunLoopMode];	// not clear whether this is part of NSRunLoopCommonModes...
-		
-		[self fixTimedQuitMenuItem];
-		[self fixStatusItemIcon];
-	}
+	[self startTimedQuitWithMinutes:[TimedQuitController runPanelForMinutesUntilQuit]];
 }
 
 - (IBAction)cancelTimedQuit:(id)sender

--- a/PrefsController.m
+++ b/PrefsController.m
@@ -115,7 +115,7 @@ static PrefsController *sharedPrefsController = nil;
 			jiggleStyle = (int)[userDefaults integerForKey:JiggleStyleDefaultsKey];
 			if (jiggleStyle == -1)
 				jiggleStyle = ([userDefaults boolForKey:ZenJiggleDefaultsKey] ? 1 : 0);
-			if ((jiggleStyle < 0) || (jiggleStyle > 2)) jiggleStyle = 0;
+			if ((jiggleStyle < 0) || (jiggleStyle > 3)) jiggleStyle = 0;	// 3 = keystroke jiggle, hidden (issue #28)
             
             jiggleDistance = [userDefaults floatForKey:JiggleDistanceDefaultsKey];
 			if (jiggleDistance < 0.0f)


### PR DESCRIPTION
Three small features for #2, #19, #28 wrapped in one PR. All are **hidden defaults knobs with no Preferences UI** — that is the entire point: the comments on those issues kept circling back to UI-complexity concerns, and on #2 you wrote *"the user interface would just explode in complexity. At this point, all I can say is: it's open source, do what you like with it."* This PR is what "do what you like" might look like without touching the visible UI at all.

## What the maintainer actually said on each (faithful quote)

- **#28** (jiggle by key click): *"It's a good idea. Jiggler is not really under active development, but if I do another update someday, I'll consider adding this."*
- **#2** (disable automatically): *"The other two are good ideas that would make a nice addition to the app."* — then later: *"the user interface would just explode in complexity. At this point, all I can say is: it's open source, do what you like with it."*
- **#19** (launch with Timed Quit on): *"Not at present, no. I'll leave this issue open to mark the feature request, but I'm not really doing new development on Jiggler nowadays."* → **soft no**. Included here because the implementation is trivial and the same defaults-only shape as the other two, but **trivial to drop from this PR if you'd prefer not to land it**. Cherry-pick of the other two changes would land #2 and #28 cleanly.

## Knobs

```bash
# #28 — keystroke jiggle: post a no-op keystroke instead of clicking / moving
defaults write com.stick.app.jiggler JiggleStyle -int 3
defaults write com.stick.app.jiggler JiggleKeystrokeKeyCode -int 120   # F2 by default

# #2 — auto-disable: flip the master switch OFF after N minutes from launch
defaults write com.stick.app.jiggler DisableAfterMinutes -int 480   # 8h

# #19 — start Timed Quit automatically on launch
defaults write com.stick.app.jiggler TimedQuitAtLaunchMinutes -int 240   # 4h
```

Set to 0 / remove a key to disable that feature.

## Implementation

| Issue | Where the code lands |
|---|---|
| #28 | New `else if (jiggleStyle == 3) { … CGEventCreateKeyboardEvent + Post … }` branch in `-periodicJiggleStatusCheck:`. `PrefsController` upper-bound validation bumped from 2 → 3 so the new style survives a load. Preferences radio matrix shows no selection while `jiggleStyle == 3` (no matching tag); the three visible styles are unchanged. |
| #19 | `-timedQuit:` is refactored to call a new `-startTimedQuitWithMinutes:` helper that owns the timer setup. Both the menu-driven path and the launch-time `TimedQuitAtLaunchMinutes` check go through the same code. No behavioural change to the existing menu flow. |
| #2 | One `dispatch_after` at the end of `-applicationDidFinishLaunching:`, captured `__weak` so app quit cleans up. Skips the flip if the master switch is already off. Persists the new state to NSUserDefaults so a quick relaunch doesn't re-enable. |

## Why hidden, not visible UI

These three together would mean at least one new checkbox in Preferences plus probably hours/minutes fields per feature, on a window that already says *"Jiggler is already quite complicated for such a simple concept!"* in the README. The defaults-only shape:

- Keeps the visible UI exactly as-is.
- Costs nothing for users who never touch `defaults write`.
- Gives the small set of users who asked for these features a way to get them.
- Is easy to revert per-knob (each is fully isolated; no shared state).

## Verification

`xcodebuild -configuration Debug build` → BUILD SUCCEEDED, no warnings.

Tested locally:
- `JiggleStyle=3` + short `JiggleSeconds`: confirms `+++ activate` log fires and no crash.
- `DisableAfterMinutes=1` + run >60s: master switch flips off, icon updates, app keeps running.
- `TimedQuitAtLaunchMinutes=5` + launch: countdown appears in menu, timer ticks.

## How to land partially

If you'd rather not have #19, the `launchMinutes`/`startTimedQuitWithMinutes:` extraction can come out separately. The other two features are independent of each other and of #19.